### PR TITLE
Use ^[[G instead of ^[[1000D

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ x.cursorBackward = function (count) {
 	return ESC + (typeof count === 'number' ? count : 1) + 'D';
 };
 
-x.cursorLeft = ESC + '1000D';
+x.cursorLeft = ESC + 'G';
 x.cursorSavePosition = ESC + 's';
 x.cursorRestorePosition = ESC + 'u';
 x.cursorGetPosition = ESC + '6n';


### PR DESCRIPTION
`cursorLeft` currently uses the equivalent escape of _move 1000 characters left_, which (probably as a bug) seems to misbehave in certain emulators. Plus, for people who like really tiny text ([like me!](http://i.imgur.com/RZrt3lm.png)) 1000 might actually not cut it.

Instead, _horizontal absolute (1)_ is the correct escape that should be used. I can see why it was avoided (as it's not "officially" supported in older version of Windows).

However, Node.js uses libuv which handles (see: emulates) a lot of the TTY stuff on windows for us. You can see its specific handling of `^[[G` [in `win/tty.c` of libuv](https://github.com/libuv/libuv/blob/v1.x/src/win/tty.c#L1935-L1941).

Ref: sindresorhus/log-update#16