### PR TITLE
Require `x` argument in `cursorTo()` and `cursorMove()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const isTerminalApp = process.env.TERM_PROGRAM === 'Apple_Terminal';
 
 x.cursorTo = function (x, y) {
 	if (arguments.length === 0) {
-		return ESC + 'H';
+		throw new Error('The `x` argument is required');
 	}
 
 	if (arguments.length === 1) {
@@ -16,6 +16,10 @@ x.cursorTo = function (x, y) {
 };
 
 x.cursorMove = (x, y) => {
+	if (x === undefined || x === null) {
+		throw new Error('The `x` argument is required');
+	}
+
 	let ret = '';
 
 	if (x < 0) {

--- a/index.js
+++ b/index.js
@@ -4,11 +4,11 @@ const ESC = '\u001B[';
 const isTerminalApp = process.env.TERM_PROGRAM === 'Apple_Terminal';
 
 x.cursorTo = function (x, y) {
-	if (arguments.length === 0) {
-		throw new Error('The `x` argument is required');
+	if (typeof x !== 'number') {
+		throw new TypeError('The `x` argument is required');
 	}
 
-	if (arguments.length === 1) {
+	if (typeof y !== 'number') {
 		return ESC + (x + 1) + 'G';
 	}
 
@@ -16,8 +16,8 @@ x.cursorTo = function (x, y) {
 };
 
 x.cursorMove = (x, y) => {
-	if (x === undefined || x === null) {
-		throw new Error('The `x` argument is required');
+	if (typeof x !== 'number') {
+		throw new TypeError('The `x` argument is required');
 	}
 
 	let ret = '';

--- a/readme.md
+++ b/readme.md
@@ -23,11 +23,9 @@ process.stdout.write(ansiEscapes.cursorUp(2) + ansiEscapes.cursorLeft);
 
 ## API
 
-### cursorTo([x, [y]])
+### cursorTo(x, [y])
 
 Set the absolute position of the cursor. `x0` `y0` is the top left of the screen.
-
-Specify either both `x` & `y`, only `x`, or nothing.
 
 ### cursorMove(x, [y])
 


### PR DESCRIPTION
It's a breaking change.

I don't know why I allowed and documented that `cursorTo()` could be used without arguments, but it makes no sense to me now.