### PR TITLE
Refactor TypeScript definition to CommonJS compatible export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,28 +1,30 @@
 /// <reference types="node"/>
 import {LiteralUnion} from 'type-fest';
 
-export interface ImageOptions {
-	/**
-	The width is given as a number followed by a unit, or the word `'auto'`.
+declare namespace ansiEscapes {
+	interface ImageOptions {
+		/**
+		The width is given as a number followed by a unit, or the word `'auto'`.
 
-	- `N`: N character cells.
-	- `Npx`: N pixels.
-	- `N%`: N percent of the session's width or height.
-	- `auto`: The image's inherent size will be used to determine an appropriate dimension.
-	*/
-	readonly width?: LiteralUnion<'auto', number | string>;
+		- `N`: N character cells.
+		- `Npx`: N pixels.
+		- `N%`: N percent of the session's width or height.
+		- `auto`: The image's inherent size will be used to determine an appropriate dimension.
+		*/
+		readonly width?: LiteralUnion<'auto', number | string>;
 
-	/**
-	The height is given as a number followed by a unit, or the word `'auto'`.
+		/**
+		The height is given as a number followed by a unit, or the word `'auto'`.
 
-	- `N`: N character cells.
-	- `Npx`: N pixels.
-	- `N%`: N percent of the session's width or height.
-	- `auto`: The image's inherent size will be used to determine an appropriate dimension.
-	*/
-	readonly height?: LiteralUnion<'auto', number | string>;
+		- `N`: N character cells.
+		- `Npx`: N pixels.
+		- `N%`: N percent of the session's width or height.
+		- `auto`: The image's inherent size will be used to determine an appropriate dimension.
+		*/
+		readonly height?: LiteralUnion<'auto', number | string>;
 
-	readonly preserveAspectRatio?: boolean;
+		readonly preserveAspectRatio?: boolean;
+	}
 }
 
 declare const ansiEscapes: {
@@ -182,7 +184,7 @@ declare const ansiEscapes: {
 
 	@param buffer - Buffer of an image. Usually read in with `fs.readFile()`.
 	*/
-	image(buffer: Buffer, options?: ImageOptions): string;
+	image(buffer: Buffer, options?: ansiEscapes.ImageOptions): string;
 
 	iTerm: {
 		/**
@@ -192,6 +194,9 @@ declare const ansiEscapes: {
 		*/
 		setCwd(cwd: string): string;
 	};
+
+	// TODO: remove this in the next major version
+	default: typeof ansiEscapes;
 };
 
-export default ansiEscapes;
+export = ansiEscapes;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const ansiEscapes = module.exports;
+// TODO: remove this in the next major version
 module.exports.default = ansiEscapes;
 
 const ESC = '\u001B[';

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
-import {expectType} from 'tsd-check';
-import ansiEscapes from '.';
+import {expectType} from 'tsd';
+import ansiEscapes = require('.');
 
 expectType<string>(ansiEscapes.cursorTo(0));
 expectType<string>(ansiEscapes.cursorTo(0, 1));

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"node": ">=8"
 	},
 	"scripts": {
-		"test": "xo && ava && tsd-check"
+		"test": "xo && ava && tsd"
 	},
 	"files": [
 		"index.js",
@@ -48,9 +48,9 @@
 		"type-fest": "^0.3.0"
 	},
 	"devDependencies": {
-		"@types/node": "^11.11.3",
-		"ava": "^1.3.1",
-		"tsd-check": "^0.5.0",
+		"@types/node": "^11.12.2",
+		"ava": "^1.4.1",
+		"tsd": "^0.7.1",
 		"xo": "^0.24.0"
 	}
 }


### PR DESCRIPTION
We have to move to the `export = ` syntax in TS because of this: https://github.com/sindresorhus/mem/issues/31#issuecomment-475310328.