### PR TITLE
Fix readme typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,11 +41,11 @@ Move cursor down a specific amount of rows. Default is `1`.
 
 ### cursorForward(count)
 
-Move cursor forward a specific amount of rows. Default is `1`.
+Move cursor forward a specific amount of columns. Default is `1`.
 
 ### cursorBackward(count)
 
-Move cursor backward a specific amount of rows. Default is `1`.
+Move cursor backward a specific amount of columns. Default is `1`.
 
 ### cursorLeft
 


### PR DESCRIPTION
Moving forwards and backwards changes the cursor column not row