### PR TITLE
Fix saving and restoring cursor position on macOS Terminal.app

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,8 +49,8 @@ ansiEscapes.cursorForward = (count = 1) => ESC + count + 'C';
 ansiEscapes.cursorBackward = (count = 1) => ESC + count + 'D';
 
 ansiEscapes.cursorLeft = ESC + 'G';
-ansiEscapes.cursorSavePosition = ESC + (isTerminalApp ? '7' : 's');
-ansiEscapes.cursorRestorePosition = ESC + (isTerminalApp ? '8' : 'u');
+ansiEscapes.cursorSavePosition = isTerminalApp ? '\u001B7' : ESC + 's';
+ansiEscapes.cursorRestorePosition = isTerminalApp ? '\u001B8' : ESC + 'u';
 ansiEscapes.cursorGetPosition = ESC + '6n';
 ansiEscapes.cursorNextLine = ESC + 'E';
 ansiEscapes.cursorPrevLine = ESC + 'F';


### PR DESCRIPTION
Fixes #15 (see issue for details).

Here's an example of our CLI output before the fix:

![Screenshot 2019-07-31 at 17 34 06](https://user-images.githubusercontent.com/5373776/62225875-8993d780-b3b9-11e9-98ed-63a2d85c73c4.png)

And here's how it looks with the fix:

![Screenshot 2019-07-31 at 17 34 47](https://user-images.githubusercontent.com/5373776/62225900-9284a900-b3b9-11e9-948e-0defb6f390ec.png)
