### PR TITLE
Add `iTerm.annotation()` method

### DIFF
--- a/example.js
+++ b/example.js
@@ -3,3 +3,9 @@ const fs = require('fs');
 const ansiEscapes = require('.');
 
 console.log(ansiEscapes.image(fs.readFileSync('fixture.jpg'), {width: 15}));
+
+const text = 'this text will be annotated';
+console.log(text);
+process.stdout.write(ansiEscapes.cursorPrevLine);
+console.log(ansiEscapes.iTerm.annotation('this is an annotation', {length: text.length}));
+console.log();

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,28 @@ declare namespace ansiEscapes {
 
 		readonly preserveAspectRatio?: boolean;
 	}
+
+	interface AnnotationOptions {
+		/**
+		Nonzero number of cells to annotate. Defaults to remainder of line.
+		*/
+		readonly length?: number;
+
+		/**
+		Starting X coordinate; defaults to cursor position; must be used with `y` and `length`.
+		 */
+		readonly x?: number;
+
+		/**
+		Starting Y coordinate; defaults to cursor position; must be used with `x` and `length`.
+		*/
+		readonly y?: number;
+
+		/**
+		If `true`, create a "hidden" annotation. Annotations created this way can be shown using the "Show Annotations" iTerm command.
+		*/
+		readonly isHidden?: boolean;
+	}
 }
 
 declare const ansiEscapes: {
@@ -193,6 +215,19 @@ declare const ansiEscapes: {
 		@param cwd - Current directory. Default: `process.cwd()`.
 		*/
 		setCwd(cwd: string): string;
+
+		/**
+		An annotation looks like this when shown:
+
+		![screenshot of iTerm annotation](https://user-images.githubusercontent.com/924465/64382136-b60ac700-cfe9-11e9-8a35-9682e8dc4b72.png)
+
+		See the [iTerm Proprietary Escape Codes documentation](https://iterm2.com/documentation-escape-codes.html) for more information.
+
+		@param message - Message to display within annotation. The `|` character is disallowed and will be stripped.
+		@param options - Options to control display of annotation.
+		@returns Escape code which will create an annotation when displayed in terminal.
+		*/
+		annotation(message: string, options?: ansiEscapes.AnnotationOptions): string;
 	};
 
 	// TODO: remove this in the next major version

--- a/index.d.ts
+++ b/index.d.ts
@@ -235,7 +235,7 @@ declare const ansiEscapes: {
 
 		See the [iTerm Proprietary Escape Codes documentation](https://iterm2.com/documentation-escape-codes.html) for more information.
 
-		@param message - Message to display within annotation. The `|` character is disallowed and will be stripped.
+		@param message - The message to display within the annotation. The `|` character is disallowed and will be stripped.
 		@returns An escape code which will create an annotation when printed in iTerm2.
 		*/
 		annotation(message: string, options?: ansiEscapes.AnnotationOptions): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,17 +28,27 @@ declare namespace ansiEscapes {
 
 	interface AnnotationOptions {
 		/**
-		Nonzero number of cells to annotate. Defaults to remainder of line.
+		Nonzero number of cells to annotate.
+
+		Default: The remainder of the line.
 		*/
 		readonly length?: number;
 
 		/**
-		Starting X coordinate; defaults to cursor position; must be used with `y` and `length`.
-		 */
+		Starting X coordinate.
+
+		Must be used with `y` and `length`.
+
+		Default: The cursor position
+		*/
 		readonly x?: number;
 
 		/**
-		Starting Y coordinate; defaults to cursor position; must be used with `x` and `length`.
+		Starting Y coordinate.
+
+		Must be used with `x` and `length`.
+
+		Default: Cursor position.
 		*/
 		readonly y?: number;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -236,8 +236,7 @@ declare const ansiEscapes: {
 		See the [iTerm Proprietary Escape Codes documentation](https://iterm2.com/documentation-escape-codes.html) for more information.
 
 		@param message - Message to display within annotation. The `|` character is disallowed and will be stripped.
-		@param options - Options to control display of annotation.
-		@returns Escape code which will create an annotation when displayed in terminal.
+		@returns An escape code which will create an annotation when printed in iTerm2.
 		*/
 		annotation(message: string, options?: ansiEscapes.AnnotationOptions): string;
 	};

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,7 @@ declare namespace ansiEscapes {
 
 	interface AnnotationOptions {
 		/**
-		Nonzero number of cells to annotate.
+		Nonzero number of columns to annotate.
 
 		Default: The remainder of the line.
 		*/
@@ -53,7 +53,9 @@ declare namespace ansiEscapes {
 		readonly y?: number;
 
 		/**
-		If `true`, create a "hidden" annotation. Annotations created this way can be shown using the "Show Annotations" iTerm command.
+		Create a "hidden" annotation.
+		
+		Annotations created this way can be shown using the "Show Annotations" iTerm command.
 		*/
 		readonly isHidden?: boolean;
 	}

--- a/index.js
+++ b/index.js
@@ -128,5 +128,27 @@ ansiEscapes.image = (buffer, options = {}) => {
 };
 
 ansiEscapes.iTerm = {
-	setCwd: (cwd = process.cwd()) => `${OSC}50;CurrentDir=${cwd}${BEL}`
+	setCwd: (cwd = process.cwd()) => `${OSC}50;CurrentDir=${cwd}${BEL}`,
+
+	annotation: (message, options = {}) => {
+		let ret = `${OSC}1337;`;
+		const hasX = typeof options.x !== 'undefined';
+		const hasY = typeof options.y !== 'undefined';
+		if ((hasX || hasY) && !(hasX && hasY && typeof options.length !== 'undefined')) {
+			throw new Error('`x`, `y` and `length` must be defined when `x` or `y` is defined');
+		}
+		// eslint-disable-next-line padding-line-between-statements
+		message = message.replace(/\|/g, '');
+		ret += options.isHidden ? 'AddHiddenAnnotation=' : 'AddAnnotation=';
+		if (options.length > 0) {
+			ret +=
+					(hasX ?
+						[message, options.length, options.x, options.y] :
+						[options.length, message]).join('|');
+		} else {
+			ret += message;
+		}
+
+		return ret + BEL;
+	}
 };

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -45,3 +45,4 @@ expectType<string>(
 	ansiEscapes.image(new Buffer(1), {preserveAspectRatio: false})
 );
 expectType<string>(ansiEscapes.iTerm.setCwd('/foo/bar'));
+expectType<string>(ansiEscapes.iTerm.annotation('foo bar'));

--- a/readme.md
+++ b/readme.md
@@ -181,7 +181,7 @@ Creates an escape code to display an "annotation" in iTerm2.
 
 An annotation looks like this when shown:
 
-![screenshot of iTerm annotation](https://user-images.githubusercontent.com/924465/64382136-b60ac700-cfe9-11e9-8a35-9682e8dc4b72.png)
+<img src="https://user-images.githubusercontent.com/924465/64382136-b60ac700-cfe9-11e9-8a35-9682e8dc4b72.png" width="500">
 
 See the [iTerm Proprietary Escape Codes documentation](https://iterm2.com/documentation-escape-codes.html) for more information.
 
@@ -189,7 +189,7 @@ See the [iTerm Proprietary Escape Codes documentation](https://iterm2.com/docume
 
 Type: `string`
 
-Message to display within annotation.
+The message to display within the annotation.
 
 The `|` character is disallowed and will be stripped.
 

--- a/readme.md
+++ b/readme.md
@@ -175,6 +175,52 @@ Default: `process.cwd()`
 
 [Inform iTerm2](https://www.iterm2.com/documentation-escape-codes.html) of the current directory to help semantic history and enable [Cmd-clicking relative paths](https://coderwall.com/p/b7e82q/quickly-open-files-in-iterm-with-cmd-click).
 
+### iTerm.annotation(message, options?)
+
+Creates an escape code to display an "annotation" in iTerm2.
+
+An annotation looks like this when shown:
+
+![screenshot of iTerm annotation](https://user-images.githubusercontent.com/924465/64382136-b60ac700-cfe9-11e9-8a35-9682e8dc4b72.png)
+
+See the [iTerm Proprietary Escape Codes documentation](https://iterm2.com/documentation-escape-codes.html) for more information.
+
+#### message
+
+Type: `string`
+
+Message to display within annotation. The `|` character is disallowed and will be stripped.
+
+#### options
+
+Type: `object`
+
+Options to control display of annotation.
+
+##### length
+
+Type: `number`
+
+Nonzero number of cells to annotate. Defaults to remainder of line.
+
+##### x
+
+Type: `number`
+
+Starting X coordinate; defaults to cursor position; must be used with `y` and `length`.
+
+##### y
+
+Type: `number`
+
+Starting Y coordinate; defaults to cursor position; must be used with `x` and `length`.
+
+##### isHidden
+
+Type: `boolean`
+Default: `false`
+
+If `true`, create a "hidden" annotation. Annotations created this way can be shown using the "Show Annotations" iTerm command.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -189,38 +189,47 @@ See the [iTerm Proprietary Escape Codes documentation](https://iterm2.com/docume
 
 Type: `string`
 
-Message to display within annotation. The `|` character is disallowed and will be stripped.
+Message to display within annotation.
+
+The `|` character is disallowed and will be stripped.
 
 #### options
 
 Type: `object`
 
-Options to control display of annotation.
-
 ##### length
 
-Type: `number`
+Type: `number`\
+Default: The remainder of the line
 
-Nonzero number of cells to annotate. Defaults to remainder of line.
+Nonzero number of columns to annotate.
 
 ##### x
 
-Type: `number`
+Type: `number`\
+Default: Cursor position
 
-Starting X coordinate; defaults to cursor position; must be used with `y` and `length`.
+Starting X coordinate.
+
+Must be used with `y` and `length`.
 
 ##### y
 
-Type: `number`
+Type: `number`\
+Default: Cursor position
 
-Starting Y coordinate; defaults to cursor position; must be used with `x` and `length`.
+Starting Y coordinate.
+
+Must be used with `x` and `length`.
 
 ##### isHidden
 
-Type: `boolean`
+Type: `boolean`\
 Default: `false`
 
-If `true`, create a "hidden" annotation. Annotations created this way can be shown using the "Show Annotations" iTerm command.
+Create a "hidden" annotation.
+
+Annotations created this way can be shown using the "Show Annotations" iTerm command.
 
 ## Related
 


### PR DESCRIPTION
See https://iterm2.com/documentation-escape-codes.html

Example:

![image](https://user-images.githubusercontent.com/924465/62239743-4f5f1180-b38a-11e9-8a4b-23ab8d2a4756.png)
