### PR TITLE
Fix TypeScript signature for `iTerm.setCwd`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -226,7 +226,7 @@ declare const ansiEscapes: {
 
 		@param cwd - Current directory. Default: `process.cwd()`.
 		*/
-		setCwd(cwd: string): string;
+		setCwd(cwd?: string): string;
 
 		/**
 		An annotation looks like this when shown:


### PR DESCRIPTION
Docs and code show that the argument is optional. Make it so!