### PR TITLE
Support in-browser uses

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'u
 
 const isTerminalApp = isBrowser && process.env.TERM_PROGRAM === 'Apple_Terminal';
 const isWindows = isBrowser && process.platform === 'win32';
-const cwdFunc = isBrowser ? () => {
+const cwdFunction = isBrowser ? () => {
 	throw new Error('`process.cwd()` only works in Node.js, not the browser.');
 } : process.cwd;
 
@@ -133,7 +133,7 @@ ansiEscapes.image = (buffer, options = {}) => {
 };
 
 ansiEscapes.iTerm = {
-	setCwd: (cwd = cwdFunc()) => `${OSC}50;CurrentDir=${cwd}${BEL}`,
+	setCwd: (cwd = cwdFunction()) => `${OSC}50;CurrentDir=${cwd}${BEL}`,
 
 	annotation(message, options = {}) {
 		let returnValue = `${OSC}1337;`;

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const OSC = '\u001B]';
 const BEL = '\u0007';
 const SEP = ';';
 
+/* global window */
 const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined';
 
 let isTerminalApp_;

--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ const SEP = ';';
 /* global window */
 const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined';
 
-const isTerminalApp = isBrowser && process.env.TERM_PROGRAM === 'Apple_Terminal';
-const isWindows = isBrowser && process.platform === 'win32';
+const isTerminalApp = !isBrowser && process.env.TERM_PROGRAM === 'Apple_Terminal';
+const isWindows = !isBrowser && process.platform === 'win32';
 const cwdFunction = isBrowser ? () => {
 	throw new Error('`process.cwd()` only works in Node.js, not the browser.');
 } : process.cwd;

--- a/index.js
+++ b/index.js
@@ -8,23 +8,11 @@ const SEP = ';';
 /* global window */
 const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined';
 
-let isTerminalApp_;
-let platform_ = 'browser';
-let cwdFunc_ = () => {
-	throw new Error('NodeJS.Process.cwd() doesn\'t work in Browser.');
-};
-
-if (isBrowser) {
-	isTerminalApp_ = false;
-} else {
-	isTerminalApp_ = process.env.TERM_PROGRAM === 'Apple_Terminal';
-	platform_ = process.platform;
-	cwdFunc_ = process.cwd;
-}
-
-const isTerminalApp = isTerminalApp_;
-const platform = platform_;
-const cwdFunc = cwdFunc_;
+const isTerminalApp = isBrowser && process.env.TERM_PROGRAM === 'Apple_Terminal';
+const isWindows = isBrowser && process.platform === 'win32';
+const cwdFunc = isBrowser ? () => {
+	throw new Error('`process.cwd()` only works in Node.js, not the browser.');
+} : process.cwd;
 
 const ansiEscapes = {};
 
@@ -101,7 +89,7 @@ ansiEscapes.scrollDown = ESC + 'T';
 
 ansiEscapes.clearScreen = '\u001Bc';
 
-ansiEscapes.clearTerminal = platform === 'win32'
+ansiEscapes.clearTerminal = isWindows
 	? `${ansiEscapes.eraseScreen}${ESC}0f`
 	// 1. Erases the screen (Only done in case `2` is not supported)
 	// 2. Erases the whole screen including scrollback buffer

--- a/index.js
+++ b/index.js
@@ -1,21 +1,26 @@
+import process from 'node:process';
+
 const ESC = '\u001B[';
 const OSC = '\u001B]';
 const BEL = '\u0007';
 const SEP = ';';
 
-const isBrowser = typeof window !== "undefined" && typeof window.document !== "undefined";
+const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined';
 
 let isTerminalApp_;
 let platform_ = 'browser';
-let cwdFunc_ = () => {throw new Error('NodeJS.Process.cwd() doesn\'t work in Browser.');}
+let cwdFunc_ = () => {
+	throw new Error('NodeJS.Process.cwd() doesn\'t work in Browser.');
+};
+
 if (isBrowser) {
-  isTerminalApp_ = false;
+	isTerminalApp_ = false;
 } else {
-	const process = require('node:process');
 	isTerminalApp_ = process.env.TERM_PROGRAM === 'Apple_Terminal';
 	platform_ = process.platform;
 	cwdFunc_ = process.cwd;
 }
+
 const isTerminalApp = isTerminalApp_;
 const platform = platform_;
 const cwdFunc = cwdFunc_;

--- a/readme.md
+++ b/readme.md
@@ -10,8 +10,6 @@ npm install ansi-escapes
 
 ## Usage
 
-### Use within terminal
-
 ```js
 import ansiEscapes from 'ansi-escapes';
 
@@ -20,18 +18,17 @@ process.stdout.write(ansiEscapes.cursorUp(2) + ansiEscapes.cursorLeft);
 //=> '\u001B[2A\u001B[1000D'
 ```
 
-### Use with xterm.js
+**You can also use it in the browser with Xterm.js:**
 
 ```js
 import ansiEscapes from 'ansi-escapes';
-import { Terminal } from 'xterm';
+import {Terminal} from 'xterm';
 import 'xterm/css/xterm.css';
 
-...
-const term = new Terminal({...});
-...
+const terminal = new Terminal({…});
+
 // Moves the cursor two rows up and to the left
-term.write(ansiEscapes.cursorUp(2) + ansiEscapes.cursorLeft);
+terminal.write(ansiEscapes.cursorUp(2) + ansiEscapes.cursorLeft);
 //=> '\u001B[2A\u001B[1000D'
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -10,11 +10,28 @@ npm install ansi-escapes
 
 ## Usage
 
+### Use within terminal
+
 ```js
 import ansiEscapes from 'ansi-escapes';
 
 // Moves the cursor two rows up and to the left
 process.stdout.write(ansiEscapes.cursorUp(2) + ansiEscapes.cursorLeft);
+//=> '\u001B[2A\u001B[1000D'
+```
+
+### Use with xterm.js
+
+```js
+import ansiEscapes from 'ansi-escapes';
+import { Terminal } from 'xterm';
+import 'xterm/css/xterm.css';
+
+...
+const term = new Terminal({...});
+...
+// Moves the cursor two rows up and to the left
+term.write(ansiEscapes.cursorUp(2) + ansiEscapes.cursorLeft);
 //=> '\u001B[2A\u001B[1000D'
 ```
 


### PR DESCRIPTION
Hi, thank you for your awesome work!

I'd like to developing a fake shell based on xterm.js in frontend. I found that Vite dev server gives a warning like that:

```
Module "node:process" has been externalized for browser compatibility. Cannot access "node:process.env" in client code. See http://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
get @ browser-external:node:process:9
```

The `TERM_PROGRAM` env variable also does not exist in browser: 

```
TypeError: Cannot read properties of undefined (reading 'TERM_PROGRAM')
```

According to the [Node | Webpack](https://webpack.js.org/configuration/node/#node-process) documentation, the webpack can make polyfills for different node functions, but it appears as the node.process is a "mock";

> "mock": Provide a mock that implements the expected interface but has little or no functionality.

So I added some code to judge the current running environment in advance, and moved some code related to Node to conditional judgment.