### PR TITLE
Add escapes for entering/exiting the alternative screen

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -200,6 +200,16 @@ declare const ansiEscapes: {
 	clearTerminal: string;
 
 	/**
+	Enter the [alternative screen](https://terminalguide.namepad.de/mode/p47/).
+	*/
+	enterAlternativeScreen: string;
+
+	/**
+	Exit the [alternative screen](https://terminalguide.namepad.de/mode/p47/), assuming `enterAlternativeScreen` was called before.
+	*/
+	exitAlternativeScreen: string;
+
+	/**
 	Output a beeping sound.
 	*/
 	beep: string;

--- a/index.js
+++ b/index.js
@@ -97,6 +97,9 @@ ansiEscapes.clearTerminal = isWindows
 	// More info: https://www.real-world-systems.com/docs/ANSIcode.html
 	: `${ansiEscapes.eraseScreen}${ESC}3J${ESC}H`;
 
+ansiEscapes.enterAlternativeScreen = ESC + '?1049h';
+ansiEscapes.exitAlternativeScreen = ESC + '?1049l';
+
 ansiEscapes.beep = BEL;
 
 ansiEscapes.link = (text, url) => [

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -33,6 +33,8 @@ expectType<string>(ansiEscapes.scrollUp);
 expectType<string>(ansiEscapes.scrollDown);
 expectType<string>(ansiEscapes.clearScreen);
 expectType<string>(ansiEscapes.clearTerminal);
+expectType<string>(ansiEscapes.enterAlternativeScreen);
+expectType<string>(ansiEscapes.exitAlternativeScreen);
 expectType<string>(ansiEscapes.beep);
 expectType<string>(ansiEscapes.link('foo', 'https://foo.bar'));
 expectType<string>(ansiEscapes.image(Buffer.from('1')));

--- a/readme.md
+++ b/readme.md
@@ -134,6 +134,14 @@ Clear the terminal screen. (Viewport)
 
 Clear the whole terminal, including scrollback buffer. (Not just the visible part of it)
 
+### enterAlternativeScreen
+
+Enter the [alternative screen](https://terminalguide.namepad.de/mode/p47/).
+
+### exitAlternativeScreen
+
+Exit the [alternative screen](https://terminalguide.namepad.de/mode/p47/), assuming `enterAlternativeScreen` was called before.
+
 ### beep
 
 Output a beeping sound.


### PR DESCRIPTION
Fixes #32.

Script to test this with:

```js
import ansiEscapes from './index.js';

console.log(ansiEscapes.enterAlternativeScreen)
console.log('Hello world')
await new Promise(resolve => setTimeout(resolve, 1000))
console.log(ansiEscapes.exitAlternativeScreen)
```


https://user-images.githubusercontent.com/697676/233954243-41195d66-2de5-44ca-8561-bf07eda31947.mp4

