### PR TITLE
Update link to VT100 escape sequences site in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # ansi-escapes
 
-> [ANSI escape codes](http://www.termsys.demon.co.uk/vtansi.htm) for manipulating the terminal
+> [ANSI escape codes](https://www2.ccs.neu.edu/research/gpc/VonaUtils/vona/terminal/vtansi.htm) for manipulating the terminal
 
 ## Install
 


### PR DESCRIPTION
I noticed the link in the Readme is dead. 

Via Wayback Machine I was able to find what the page used to contain:
https://web.archive.org/web/20190801232239/http://www.termsys.demon.co.uk/vtansi.htm

Then I found this page, which has the exact same content:
https://www2.ccs.neu.edu/research/gpc/VonaUtils/vona/terminal/vtansi.htm

This PR changes the link to that URL.