### PR TITLE
Fix image escape sequence

### DIFF
--- a/base.js
+++ b/base.js
@@ -133,6 +133,7 @@ export const image = (data, options = {}) => {
 
 	const imageBuffer = Buffer.from(data);
 
+	// `size` is optional in the spec, but xterm.js requires it.
 	return returnValue + `;size=${imageBuffer.byteLength}` + ':' + imageBuffer.toString('base64') + BEL;
 };
 

--- a/base.js
+++ b/base.js
@@ -131,7 +131,9 @@ export const image = (data, options = {}) => {
 		returnValue += ';preserveAspectRatio=0';
 	}
 
-	return returnValue + ':' + Buffer.from(data).toString('base64') + BEL;
+	const imageBuffer = Buffer.from(data);
+
+	return returnValue + `;size=${imageBuffer.byteLength}` + ':' + imageBuffer.toString('base64') + BEL;
 };
 
 export const iTerm = {


### PR DESCRIPTION
Added the `size` parameter to the image escape sequence to have wider compatibility with different terminal emulators that implements iTerm2 inline images protocol

From [iTerm2's specs](https://iterm2.com/documentation-images.html):

> | Key | Description of value |
> | --- | --- |
> | name   | base-64 encoded filename. Defaults to "Unnamed file". |
> | size   | File size in bytes. **Optional**; this is only used by the progress indicator. |
> | width  | Width to render. See notes below.|
> | height | Height to render. See notes below.|
> | preserveAspectRatio | If set to 0, then the image's inherent aspect ratio will not be respected; otherwise, it will fill the specified width and height as much as possible without stretching. Defaults to 1.|
> | inline | If set to 1, the file will be displayed inline. Otherwise, it will be downloaded with no visual representation in the terminal session. Defaults to 0. |

This enables images to be displayed in terminal emulators with non-standard protocol checks, e.g. xterm.js, that requires the size parameter to be set.

**To test:**
1. In VS Code, enable `terminal.integrated.enableImages` and `terminal.integrated.gpuAcceleration`
2. run this inside the integrated terminal, which uses xterm.js:
  ```javascript
  import AnsiEscapes from "ansi-escapes";
  import fs from "fs";
  
  const image = fs.readFileSync("fixture.jpg");
  console.log(AnsiEscapes.image(image));
  ```